### PR TITLE
Minor adjustments to wording in man page

### DIFF
--- a/kassiber.1
+++ b/kassiber.1
@@ -13,13 +13,13 @@
 .Op Fl a
 .Op Fl A
 .Op Fl n
-.Op Fl r Ar <rtld>
-.Op Fl p Ar <path>
-.Op Fl l Ar <lib>
-.Op Fl j Ar <jail>
-.Op Fl c Ar <chroot>
-.Ar <cmd>
-.Op Ar <arg> ...
+.Op Fl r Ar rtld
+.Op Fl p Ar path
+.Op Fl l Ar lib
+.Op Fl j Ar jail
+.Op Fl c Ar chroot
+.Ar cmd
+.Op Ar arg ...
 .\"
 .\"
 .\"
@@ -28,31 +28,37 @@ The
 .Nm
 command opens the runtime loader and an executable,
 loads the required libraries, attaches itself to a jail
-and/or chroot directory.
+and/or chroot directory before executing the loaded command.
 
-The following option are available:
+The following options are available:
 .Bl -tag -width flag
 .It Fl h
 Print the usage message and exit.
 .It Fl a
 Infer the required libraries using the runtime loader's tracing support.
-Put the inferred libaries before manually specified libraries.
+Put inferred libraries before manually specified libraries.
 .It Fl A
 Infer the required libraries using the runtime loader's tracing support.
-Put the inferred libaries after manually specified libraries.
+Put inferred libraries after manually specified libraries.
 .It Fl n
 Don't infer the required libraries. Only manually specified libraries will be loaded.
-.It Fl r Ar <rtld>
+.It Fl r Ar rtld
 Override the the default runtime loader path.
-.It Fl l Ar <lib>
+.It Fl l Ar lib
 Manually specify a library to preload. Can be specified more than once.
-.It Fl j Ar <jail>
-Set the jail to attach to.
+.It Fl j Ar jail
+Specify the jail to attach to.
 The command attaches to the jail before it chroots itself.
-.It Fl c Ar <chroot>
+.It Fl c Ar chroot
 Set the chroot directory path.
 The command chroots itself after it attached to the jail.
 .El
+.\"
+.\"
+.\"
+.Sh CAVEATS
+Many programs rely on access to further files besides just their linked
+libraries so will be unable to function usefully from within the jail.
 .\"
 .\"
 .\"


### PR DESCRIPTION
There's a few changes, some of which you may not want.

- Starting with the least controversial, are typo fixes for missing r in libraries and s in options.
- Using `<` and `>` around flag arguments is not really correct for a man page and I assume they got there by copy-pasting from the `-h` output. It's up to the `Ar` macro definition to determine how those are rendered.
- The use of "the" is unnecessary with a plural and I don't think it adds to the readability. The "set" to "specify" change I think is better but that may just be my opinion.
- While it perhaps states the obvious, I think it is worth spelling out that the command is executed in the description. Just to be precise.
- The caveats section is also adding something which may seem obvious to anyone who understands what it's doing but it may help understanding for a less knowledgeable user.

It isn't covered in this PR but I would also suggest that the description section might give a bit more detail of the purpose of the command. It currently describes what it does in quite technical terms but that may leave people wonder just why you would want to do this.

It would also benefit from an Examples section. It is perhaps most useful with the FreeBSD 15 service jails if they are much emptier (can't say because I've yet to install 15 anywhere). Unless I've missed something, your `mkdir` example from yesterday is only particularly useful if there's no `mkdir` binary in the jail. You also mentioned `ipfw` or `pfctl` I think. It'd be good to have an example that uses the shell to pass further file descriptors such as with `3</path/to/file` though that unfortunately is of limited use without fdescfs mounted in the jail.

It's not clear from the man page what the actual effect is in terms of whether libraries come before or after the inferred libraries. `rtld(1)`  could perhaps be clearer on this or perhaps details are elsewhere but you could at least make it clear whether after or before means symbols from that library get used in preference. I would never remember which of `-a` and `-A` means after and which before. `-B` might be clearer. I'm perhaps showing my age but in the past, `+` options were common for negated variants of flags. Another option would be to have two variants of `-l` allowing a mix of before/after libraries or a special argument to `-l` to give the position of the inferred libraries ( `-l-` or `-l+` perhaps).

If this does make its way into `jexec`, an `exec.inject` option for `jail(8)` might also be useful. Not sure when it should be invoked, either first after jail comes into existence or last after exec.start.